### PR TITLE
Fix delta reassignment in fit(), as well as indexing error in infer_dcfs and changes np.NINF to -np.inf

### DIFF
--- a/pharming/dcf_clustering_v2.py
+++ b/pharming/dcf_clustering_v2.py
@@ -235,7 +235,7 @@ class DCF_Clustering:
         k = # of SNV clusters 
         '''
         init_dcfs =dcfs.copy()
-        prev_likelihood = np.NINF
+        prev_likelihood = -np.inf
         self.k = len(dcfs)
 
         self.data = data 
@@ -268,7 +268,7 @@ class DCF_Clustering:
                 # if len(thresh_cn_prop) > 4 and self.data.num_snvs(ell) < 100:
                 #     continue
           
-                seg_like = np.NINF
+                seg_like = -np.inf
                 
                 if self.cna_restriction:
 
@@ -478,7 +478,7 @@ class DCF_Clustering:
         # print(elbow)
 
         #add model selection 
-               
+        # print("return from run", results_by_k[selected])
         return results_by_k[selected]#best
         
 

--- a/pharming/pharming.py
+++ b/pharming/pharming.py
@@ -94,6 +94,8 @@ class Pharming:
         G = nx.DiGraph()
         G.add_nodes_from([q for q in range(self.k)])
         for u,v in itertools.combinations(range(self.k),2):
+            print(u, delta[u])
+            print(v, delta[v])
             if delta[u] >= delta[v]:
                 G.add_edge(u,v, weight=1)
             elif delta[u] < delta[v]:
@@ -438,8 +440,10 @@ class Pharming:
        dcf_clust = DCF_Clustering(rng= self.rng, nrestarts=18, cna_restriction=1)
     #    like, dcfs , _, _, _ = dcf_clust.decifer(self.data, np.array([0.179, 0.241, 0.32, 0.424, 0.985]) )
     #    print(like)
-       like, dcfs , _, _, _= dcf_clust.run(self.data, k_vals=[self.k], cores=6)
+       like, dcfs , _, _, _, _, _= dcf_clust.run(self.data, k_vals=[self.k], cores=6)
        self.delta = {i: dcfs[i] for i in range(len(dcfs))}
+       print(self.delta)
+       return self.delta
 
     def preprocess(self, seg_list, delta):
 
@@ -490,7 +494,7 @@ class Pharming:
         print("Plowing the field.... ")
         if self.delta is None:
             self.delta = self.infer_dcfs()
-
+        print("self.delta: ", self.delta)
         if Tm is not None:
             scriptTm = [Tm]
             for T_m in scriptTm:

--- a/pharming/pharming.py
+++ b/pharming/pharming.py
@@ -94,8 +94,6 @@ class Pharming:
         G = nx.DiGraph()
         G.add_nodes_from([q for q in range(self.k)])
         for u,v in itertools.combinations(range(self.k),2):
-            print(u, delta[u])
-            print(v, delta[v])
             if delta[u] >= delta[v]:
                 G.add_edge(u,v, weight=1)
             elif delta[u] < delta[v]:
@@ -442,8 +440,6 @@ class Pharming:
     #    print(like)
        like, dcfs , _, _, _, _, _= dcf_clust.run(self.data, k_vals=[self.k], cores=6)
        self.delta = {i: dcfs[i] for i in range(len(dcfs))}
-       print(self.delta)
-       return self.delta
 
     def preprocess(self, seg_list, delta):
 
@@ -493,7 +489,7 @@ class Pharming:
         
         print("Plowing the field.... ")
         if self.delta is None:
-            self.delta = self.infer_dcfs()
+            self.infer_dcfs()
         print("self.delta: ", self.delta)
         if Tm is not None:
             scriptTm = [Tm]


### PR DESCRIPTION
### Summary
This PR addresses two core issues in the pipeline initialization and numeric calculations:
1. **`self.delta` population:** Fixes a bug in `fit()` where `self.delta` was being called but not properly retained or updated due to missing context assignments. It now directly triggers `self.infer_dcfs()` to correctly populate the internal dictionary state before evaluation.
2.  `infer_dcfs()` had a parsing error where it tried breaking up a dictionary of size 7 returned by dcf_clust.run into 5 variables. MY fix added 2 extra variables to ensure that the algorithm didn't break when that line was called
3. **Likelihood initialization:** Replaces outdated `np.NINF` (negative infinity) references with standard `-np.inf` inside `pharming/dcf_clustering_v2.py` (`decifer` method) to ensure alignment with modern NumPy behaviors.

### Changes
* **`pharming/pharming.py`**: Updated `fit()` execution path to cleanly invoke `self.infer_dcfs()` and added trace logs. Adjusted `dcf_clust.run()` unpacking parameters.
* **`pharming/dcf_clustering_v2.py`**: Cleaned up legacy negative infinity variable calls (`np.NINF` -> `-np.inf`).